### PR TITLE
Add command line option to bind to all interfaces (or specific IP)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,7 @@ commander
 //  .version(meta.version)
   .usage('[options] <endpoint>')
   .option('-p, --port <n>', 'Local proxy port, default 9200', parseInt)
+  .option('-p, --bindIf <ip>', 'Bind to interface, defaults to 127.0.0.1', /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/, '127.0.0.1')
   .parse(process.argv);
 
 if (commander.args.length != 1) {
@@ -33,7 +34,7 @@ var config = {
   endpoint: endpoint,
   region: region,
   port: commander.port || 9200,
-  bindAddress: '127.0.0.1'
+  bindAddress: commander.bindIf
 }
 
 proxy.run(config);

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ commander
 //  .version(meta.version)
   .usage('[options] <endpoint>')
   .option('-p, --port <n>', 'Local proxy port, default 9200', parseInt)
-  .option('-p, --bindIf <ip>', 'Bind to interface, defaults to 127.0.0.1', /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/, '127.0.0.1')
+  .option('-b, --bindIf <ip>', 'Bind to interface, defaults to 127.0.0.1', /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/, '127.0.0.1')
   .parse(process.argv);
 
 if (commander.args.length != 1) {

--- a/proxy.js
+++ b/proxy.js
@@ -45,6 +45,9 @@ function run(config) {
     awsReq.headers['presigned-expires'] = false;
     awsReq.headers['Host'] = awsEndpoint.host;
 
+    if (req.headers['content-type'])
+        awsReq.headers['Content-Type'] = req.headers['content-type'];
+
     if (Buffer.isBuffer(req.body)) {
       awsReq.body = req.body;
     }


### PR DESCRIPTION

Strict `Content-Type` checking: https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests